### PR TITLE
[비교하기 페이지] 테이블 컴포넌트 및 로직 구현

### DIFF
--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -1,14 +1,10 @@
-import ObjectChip from '@/components/Compare/ObjectChip';
-import SubjectChip from '@/components/Compare/SubjectChip';
+import Table from '@/components/Compare/Table';
 
 export default function ComparePage() {
   return (
     <>
       <div>
-        <SubjectChip name={'비교 상품'} />
-      </div>
-      <div>
-        <ObjectChip name={'비교 상품'} />
+        <Table SubjectProduct={'상품 1'} ObjectProduct={'상품 2'} />
       </div>
     </>
   );

--- a/src/components/Compare/Table/Result/Result.module.scss
+++ b/src/components/Compare/Table/Result/Result.module.scss
@@ -1,0 +1,13 @@
+.title {
+  width: 179px;
+  margin: 0 auto;
+  margin-bottom: 20px;
+  color: var(--primary, #f1f1f5);
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 28px;
+}
+
+.product {
+  color: var(--main_blue, #5097fa);
+}

--- a/src/components/Compare/Table/Result/index.tsx
+++ b/src/components/Compare/Table/Result/index.tsx
@@ -1,0 +1,4 @@
+interface ResultInterface {
+  count: number;
+  victoryProduct: string;
+}

--- a/src/components/Compare/Table/Result/index.tsx
+++ b/src/components/Compare/Table/Result/index.tsx
@@ -1,3 +1,8 @@
+import classNames from 'classnames/bind';
+import styles from './TableCompare.module.scss';
+
+const cx = classNames.bind(styles);
+
 interface ResultInterface {
   count: number;
   victoryProduct: string;
@@ -5,10 +10,11 @@ interface ResultInterface {
 
 export default function Result({ count, victoryProduct }: ResultInterface) {
   return count === 0 ? (
-    <div>무승부입니다.</div>
+    <div className={cx('title')}>무승부입니다!</div>
   ) : (
-    <div>
-      <span>{victoryProduct}</span> 상품이 승리하였습니다.
+    <div className={cx('title')}>
+      <span className={cx('product')}>{victoryProduct}</span> 상품이
+      승리하였습니다!
     </div>
   );
 }

--- a/src/components/Compare/Table/Result/index.tsx
+++ b/src/components/Compare/Table/Result/index.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames/bind';
-import styles from './TableCompare.module.scss';
+import styles from './Result.module.scss';
 
 const cx = classNames.bind(styles);
 

--- a/src/components/Compare/Table/Result/index.tsx
+++ b/src/components/Compare/Table/Result/index.tsx
@@ -2,3 +2,13 @@ interface ResultInterface {
   count: number;
   victoryProduct: string;
 }
+
+export default function Result({ count, victoryProduct }: ResultInterface) {
+  return count === 0 ? (
+    <div>무승부입니다.</div>
+  ) : (
+    <div>
+      <span>{victoryProduct}</span> 상품이 승리하였습니다.
+    </div>
+  );
+}

--- a/src/components/Compare/Table/Table.module.scss
+++ b/src/components/Compare/Table/Table.module.scss
@@ -15,7 +15,6 @@
 .table {
   width: 100%;
   height: 318px;
-  display: flex;
   justify-content: center;
   text-align: center;
   border: 1px solid var(--border, #353542);

--- a/src/components/Compare/Table/Table.module.scss
+++ b/src/components/Compare/Table/Table.module.scss
@@ -1,0 +1,34 @@
+.container {
+  text-align: center;
+  padding: 60px 0 40px;
+  color: var(--primary, #f1f1f5);
+}
+
+.description {
+  text-align: center;
+  color: var(--secondary, #9fa6b2);
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 19px;
+}
+
+.table {
+  width: 100%;
+  height: 318px;
+  display: flex;
+  justify-content: center;
+  text-align: center;
+  border: 1px solid var(--border, #353542);
+  border-radius: 12px;
+  color: var(--secondary, #9fa6b2);
+  background: var(--comp-bg, #252530);
+  border-collapse: collapse;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 10px;
+}
+
+.table-head {
+  padding: 15px 0;
+  border-bottom: 1px solid var(--border, #353542);
+}

--- a/src/components/Compare/Table/TableCompare/TableCompare.module.scss
+++ b/src/components/Compare/Table/TableCompare/TableCompare.module.scss
@@ -1,0 +1,14 @@
+.product-count {
+  text-align: center;
+  color: var(--primary, #f1f1f5);
+}
+
+.subject-victory {
+  text-align: center;
+  color: var(--green, #05d58b);
+}
+
+.object-victory {
+  text-align: center;
+  color: var(--pink, #ff2f9f);
+}

--- a/src/components/Compare/Table/TableCompare/index.tsx
+++ b/src/components/Compare/Table/TableCompare/index.tsx
@@ -103,7 +103,7 @@ export default function TableCompare({
         )}
       </tr>
       <tr>
-        <td>찜 개수</td>
+        <td>별점</td>
         <td className={cx('product-count')}>{SubjectProductRating}</td>
         <td className={cx('product-count')}>{ObjectProductRating}</td>
         {rating === 1 ? (

--- a/src/components/Compare/Table/TableCompare/index.tsx
+++ b/src/components/Compare/Table/TableCompare/index.tsx
@@ -1,3 +1,7 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable no-nested-ternary */
+/* eslint-disable consistent-return */
+/* eslint-disable array-callback-return */
 import { useEffect } from 'react';
 
 interface TableCompareInterface {
@@ -58,7 +62,7 @@ export default function TableCompare({
   );
   const findVictoryProduct = count.filter((number) => {
     if (total > 0) return number === 1;
-    else if (total < 0) return number === -1;
+    if (total < 0) return number === -1;
   }).length;
 
   const victoryProduct = total > 0 ? SubjectProduct.name : ObjectProduct.name;
@@ -67,4 +71,45 @@ export default function TableCompare({
     handleCount(findVictoryProduct);
     showVictoryProduct(!total ? '무승부' : victoryProduct);
   }, []);
+
+  return (
+    <tbody>
+      <tr>
+        <td>찜 개수</td>
+        <td>{SubjectProductFavorite}</td>
+        <td>{ObjectProductFavorite}</td>
+        {favorite === 1 ? (
+          <td>상품 1 승리</td>
+        ) : favorite === -1 ? (
+          <td>상품 2 승리</td>
+        ) : (
+          <td>무승부</td>
+        )}
+      </tr>
+      <tr>
+        <td>리뷰 개수</td>
+        <td>{SubjectProductReview}</td>
+        <td>{ObjectProductReview}</td>
+        {review === 1 ? (
+          <td>상품 1 승리</td>
+        ) : review === -1 ? (
+          <td>상품 2 승리</td>
+        ) : (
+          <td>무승부</td>
+        )}
+      </tr>
+      <tr>
+        <td>찜 개수</td>
+        <td>{SubjectProductRating}</td>
+        <td>{ObjectProductRating}</td>
+        {rating === 1 ? (
+          <td>상품 1 승리</td>
+        ) : rating === -1 ? (
+          <td>상품 2 승리</td>
+        ) : (
+          <td>무승부</td>
+        )}
+      </tr>
+    </tbody>
+  );
 }

--- a/src/components/Compare/Table/TableCompare/index.tsx
+++ b/src/components/Compare/Table/TableCompare/index.tsx
@@ -1,7 +1,7 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable no-nested-ternary */
 /* eslint-disable consistent-return */
 /* eslint-disable array-callback-return */
+/* eslint-disable no-nested-ternary */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useEffect } from 'react';
 import classNames from 'classnames/bind';
 import styles from './TableCompare.module.scss';

--- a/src/components/Compare/Table/TableCompare/index.tsx
+++ b/src/components/Compare/Table/TableCompare/index.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable consistent-return */
-/* eslint-disable array-callback-return */
 /* eslint-disable no-nested-ternary */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useEffect } from 'react';
@@ -65,8 +63,13 @@ export default function TableCompare({
     0,
   );
   const findVictoryProduct = count.filter((number) => {
-    if (total > 0) return number === 1;
-    if (total < 0) return number === -1;
+    if (total > 0) {
+      return number === 1;
+    }
+    if (total < 0) {
+      return number === -1;
+    }
+    return number === 0;
   }).length;
 
   const victoryProduct = total > 0 ? SubjectProduct.name : ObjectProduct.name;

--- a/src/components/Compare/Table/TableCompare/index.tsx
+++ b/src/components/Compare/Table/TableCompare/index.tsx
@@ -1,0 +1,37 @@
+interface TableCompareInterface {
+  SubjectProduct: any;
+  ObjectProduct: any;
+  handleCount: (value: number) => void;
+  showVictoryProduct: (value: string) => void;
+}
+
+export default function TableCompare({
+  SubjectProduct,
+  ObjectProduct,
+  handleCount,
+  showVictoryProduct,
+}: TableCompareInterface) {
+  const SubjectProductFavorite = SubjectProduct?.favoriteCount;
+  const SubjectProductReview = SubjectProduct?.reviewCount;
+  const SubjectProductRating = SubjectProduct?.rating?.toFixed(1);
+  const ObjectProductFavorite = ObjectProduct?.favoriteCount;
+  const ObjectProductReview = ObjectProduct?.reviewCount;
+  const ObjectProductRating = ObjectProduct?.rating?.toFixed(1);
+
+  const compareCount = (subject, object) => {
+    return subject === object ? 0 : subject > object ? 1 : -1;
+  };
+
+  const favorite = compareCount(
+    SubjectProductFavorite ?? 0,
+    ObjectProductFavorite ?? 0,
+  );
+  const review = compareCount(
+    SubjectProductReview ?? 0,
+    ObjectProductReview ?? 0,
+  );
+  const rating = compareCount(
+    SubjectProductRating ?? 0,
+    ObjectProductRating ?? 0,
+  );
+}

--- a/src/components/Compare/Table/TableCompare/index.tsx
+++ b/src/components/Compare/Table/TableCompare/index.tsx
@@ -3,6 +3,10 @@
 /* eslint-disable consistent-return */
 /* eslint-disable array-callback-return */
 import { useEffect } from 'react';
+import classNames from 'classnames/bind';
+import styles from './TableCompare.module.scss';
+
+const cx = classNames.bind(styles);
 
 interface TableCompareInterface {
   SubjectProduct: any;
@@ -76,38 +80,38 @@ export default function TableCompare({
     <tbody>
       <tr>
         <td>찜 개수</td>
-        <td>{SubjectProductFavorite}</td>
-        <td>{ObjectProductFavorite}</td>
+        <td className={cx('product-count')}>{SubjectProductFavorite}</td>
+        <td className={cx('product-count')}>{ObjectProductFavorite}</td>
         {favorite === 1 ? (
-          <td>상품 1 승리</td>
+          <td className={cx('subejct-victory')}>상품 1 승리</td>
         ) : favorite === -1 ? (
-          <td>상품 2 승리</td>
+          <td className={cx('object-victory')}>상품 2 승리</td>
         ) : (
-          <td>무승부</td>
+          <td className={cx('product-count')}>무승부</td>
         )}
       </tr>
       <tr>
         <td>리뷰 개수</td>
-        <td>{SubjectProductReview}</td>
-        <td>{ObjectProductReview}</td>
+        <td className={cx('product-count')}>{SubjectProductReview}</td>
+        <td className={cx('product-count')}>{ObjectProductReview}</td>
         {review === 1 ? (
-          <td>상품 1 승리</td>
+          <td className={cx('subejct-victory')}>상품 1 승리</td>
         ) : review === -1 ? (
-          <td>상품 2 승리</td>
+          <td className={cx('object-victory')}>상품 2 승리</td>
         ) : (
-          <td>무승부</td>
+          <td className={cx('product-count')}>무승부</td>
         )}
       </tr>
       <tr>
         <td>찜 개수</td>
-        <td>{SubjectProductRating}</td>
-        <td>{ObjectProductRating}</td>
+        <td className={cx('product-count')}>{SubjectProductRating}</td>
+        <td className={cx('product-count')}>{ObjectProductRating}</td>
         {rating === 1 ? (
-          <td>상품 1 승리</td>
+          <td className={cx('subejct-victory')}>상품 1 승리</td>
         ) : rating === -1 ? (
-          <td>상품 2 승리</td>
+          <td className={cx('object-victory')}>상품 2 승리</td>
         ) : (
-          <td>무승부</td>
+          <td className={cx('product-count')}>무승부</td>
         )}
       </tr>
     </tbody>

--- a/src/components/Compare/Table/TableCompare/index.tsx
+++ b/src/components/Compare/Table/TableCompare/index.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 interface TableCompareInterface {
   SubjectProduct: any;
   ObjectProduct: any;
@@ -18,7 +20,7 @@ export default function TableCompare({
   const ObjectProductReview = ObjectProduct?.reviewCount;
   const ObjectProductRating = ObjectProduct?.rating?.toFixed(1);
 
-  const compareCount = (subject, object) => {
+  const compareCount = (subject: number, object: number) => {
     return subject === object ? 0 : subject > object ? 1 : -1;
   };
 
@@ -50,5 +52,19 @@ export default function TableCompare({
     },
   );
 
-  const 
+  const total = count.reduce(
+    (accumulator, current) => accumulator + current,
+    0,
+  );
+  const findVictoryProduct = count.filter((number) => {
+    if (total > 0) return number === 1;
+    else if (total < 0) return number === -1;
+  }).length;
+
+  const victoryProduct = total > 0 ? SubjectProduct.name : ObjectProduct.name;
+
+  useEffect(() => {
+    handleCount(findVictoryProduct);
+    showVictoryProduct(!total ? '무승부' : victoryProduct);
+  }, []);
 }

--- a/src/components/Compare/Table/TableCompare/index.tsx
+++ b/src/components/Compare/Table/TableCompare/index.tsx
@@ -34,4 +34,21 @@ export default function TableCompare({
     SubjectProductRating ?? 0,
     ObjectProductRating ?? 0,
   );
+
+  const count = ['favoriteCount', 'reviewCount', 'rating'].map<number>(
+    (key) => {
+      const SubjectCount = Math.floor(SubjectProduct[key] * 10) / 10;
+      const ObjectCount = Math.floor(ObjectProduct[key] * 10) / 10;
+
+      if (SubjectCount > ObjectCount) {
+        return 1;
+      }
+      if (SubjectCount < ObjectCount) {
+        return -1;
+      }
+      return 0;
+    },
+  );
+
+  const 
 }

--- a/src/components/Compare/Table/index.tsx
+++ b/src/components/Compare/Table/index.tsx
@@ -1,9 +1,11 @@
+'use client';
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useState } from 'react';
 import classNames from 'classnames/bind';
-import Result from './Result';
-import TableCompare from './TableCompare';
-import styles from './TableCompare.module.scss';
+import Result from '@/components/Compare/Table/Result';
+import TableCompare from '@/components/Compare/Table/TableCompare';
+import styles from './Table.module.scss';
 
 const cx = classNames.bind(styles);
 interface TableInterface {

--- a/src/components/Compare/Table/index.tsx
+++ b/src/components/Compare/Table/index.tsx
@@ -1,0 +1,4 @@
+interface TableInterface {
+  SubejctProduct: any;
+  ObjectProduct: any;
+}

--- a/src/components/Compare/Table/index.tsx
+++ b/src/components/Compare/Table/index.tsx
@@ -1,8 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useState } from 'react';
+import classNames from 'classnames/bind';
 import Result from './Result';
 import TableCompare from './TableCompare';
+import styles from './TableCompare.module.scss';
 
+const cx = classNames.bind(styles);
 interface TableInterface {
   SubjectProduct: any;
   ObjectProduct: any;
@@ -19,17 +22,19 @@ export default function Table({
 
   return (
     <>
-      <div>
+      <div className={cx('container')}>
         <Result count={count} victoryProduct={victoryProduct} />
-        <span>3가지 항목 중 {count}가지 항목에서 우세합니다.</span>
+        <span className={cx('description')}>
+          3가지 항목 중 {count}가지 항목에서 우세합니다.
+        </span>
       </div>
-      <table>
+      <table className={cx('table')}>
         <thead>
           <tr>
-            <th>기준</th>
-            <th>상품 1</th>
-            <th>상품 2</th>
-            <th>결과</th>
+            <th className={cx('table-head')}>기준</th>
+            <th className={cx('table-head')}>상품 1</th>
+            <th className={cx('table-head')}>상품 2</th>
+            <th className={cx('table-head')}>결과</th>
           </tr>
         </thead>
         <TableCompare

--- a/src/components/Compare/Table/index.tsx
+++ b/src/components/Compare/Table/index.tsx
@@ -1,4 +1,44 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { useState } from 'react';
+import Result from './Result';
+import TableCompare from './TableCompare';
+
 interface TableInterface {
-  SubejctProduct: any;
+  SubjectProduct: any;
   ObjectProduct: any;
+}
+
+export default function Table({
+  SubjectProduct,
+  ObjectProduct,
+}: TableInterface) {
+  const [count, setCount] = useState(0);
+  const [victoryProduct, setVictoryProduct] = useState('');
+  const handleCount = (value: number) => setCount(value);
+  const showVictoryProduct = (value: string) => setVictoryProduct(value);
+
+  return (
+    <>
+      <div>
+        <Result count={count} victoryProduct={victoryProduct} />
+        <span>3가지 항목 중 {count}가지 항목에서 우세합니다.</span>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>기준</th>
+            <th>상품 1</th>
+            <th>상품 2</th>
+            <th>결과</th>
+          </tr>
+        </thead>
+        <TableCompare
+          handleCount={handleCount}
+          showVictoryProduct={showVictoryProduct}
+          SubjectProduct={SubjectProduct}
+          ObjectProduct={ObjectProduct}
+        />
+      </table>
+    </>
+  );
 }


### PR DESCRIPTION
### PR Type

- [x] 기능개발(Feature)
- [ ] 버그수정(Bugfix)
- [x] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
- 비교하기 페이지 테이블 컴포넌트 구현
- 테이블 내 상품 비교 로직 구현

### 상세 내용(Describe your changes)
- 비교하기 페이지에서 사용하는 테이블 컴포넌트 구현했습니다!
- 상품1(SubjectProduct), 상품2(ObjectProduct)에 해당하는 찜, 리뷰, 별점을 변수로 받아서 각각 비교하고 상품1이 우세하면 `1`, 상품2가 우세하면 `-1`, 무승부면 `0`으로 지정해서 비교 로직 구현했습니다.
- 상품1, 상품2 데이터가 없거나, 각 값에 필요한 데이터가 없을 경우를 대비해서 0값을 입력해 놓았습니다.
- 아직 손봐야할 부분들이 있어서 작업 진행하면서 계속 수정해 나가도록 하겠습니다!

### 이미지
![image](https://github.com/Codeit-FE3-Part4-team1-Final/Mogazoa/assets/122016324/81a5b60b-4cb5-4063-b052-1748d4edeb4b)

### Issue Number or Link
#17 