### PR TITLE
[프로필 페이지] 내 프로필 페이지, 로그아웃, 상품 데이터 불러오기, 유저 페이지로 이동

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,10 +5,9 @@ const nextConfig = {
       {
         protocol: 'https',
         hostname: '*',
-      }
+      },
     ],
   },
-
 };
 
 export default nextConfig;

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,9 +1,18 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
 import ProfileSection from '@/components/Profile/ProfileSection';
+import { UserDetail } from '@/types/types';
+import { getMyDetail } from '@/utils/getUserDetail';
 
-interface Props {
-  params: { id: string };
-}
+export default async function MyProfilePage() {
+  const token = cookies().get('accessToken');
 
-export default function MyProfilePage({ params: { id } }: Props) {
-  return <ProfileSection userId={id} />;
+  if (!token) {
+    redirect('/signin');
+  }
+
+  const userDetail: UserDetail = await getMyDetail(token.value);
+  const id = userDetail.id.toString();
+
+  return <ProfileSection userId={id} userDetail={userDetail} />;
 }

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -14,5 +14,12 @@ export default async function MyProfilePage() {
   const myDetail: UserDetail = await getMyDetail(token.value);
   const id = myDetail.id.toString();
 
-  return <ProfileSection userId={id} userDetail={myDetail} />;
+  return (
+    <ProfileSection
+      userId={id}
+      userDetail={myDetail}
+      isLoggedIn
+      token={token.value}
+    />
+  );
 }

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -11,8 +11,8 @@ export default async function MyProfilePage() {
     redirect('/signin');
   }
 
-  const userDetail: UserDetail = await getMyDetail(token.value);
-  const id = userDetail.id.toString();
+  const myDetail: UserDetail = await getMyDetail(token.value);
+  const id = myDetail.id.toString();
 
-  return <ProfileSection userId={id} userDetail={userDetail} />;
+  return <ProfileSection userId={id} userDetail={myDetail} />;
 }

--- a/src/app/user/[id]/page.tsx
+++ b/src/app/user/[id]/page.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 export default async function UserProfilePage({ params: { id } }: Props) {
   const token = cookies().get('accessToken');
-  const userDetail: UserDetail = await getUserDetail(id);
+  const userDetail: UserDetail = await getUserDetail(id, token?.value);
 
   if (token) {
     const myDetail = await getMyDetail(token.value);
@@ -20,5 +20,12 @@ export default async function UserProfilePage({ params: { id } }: Props) {
     }
   }
 
-  return <ProfileSection userId={id} userDetail={userDetail} />;
+  return (
+    <ProfileSection
+      userId={id}
+      userDetail={userDetail}
+      isLoggedIn={!!token?.value}
+      token={token?.value || ''}
+    />
+  );
 }

--- a/src/app/user/[id]/page.tsx
+++ b/src/app/user/[id]/page.tsx
@@ -1,12 +1,24 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
 import ProfileSection from '@/components/Profile/ProfileSection';
 import { UserDetail } from '@/types/types';
-import { getUserDetail } from '@/utils/getUserDetail';
+import { getMyDetail, getUserDetail } from '@/utils/getUserDetail';
 
 interface Props {
   params: { id: string };
 }
 
 export default async function UserProfilePage({ params: { id } }: Props) {
+  const token = cookies().get('accessToken');
   const userDetail: UserDetail = await getUserDetail(id);
+
+  if (token) {
+    const myDetail = await getMyDetail(token.value);
+    const myId = myDetail.id.toString();
+    if (id === myId) {
+      redirect('/mypage');
+    }
+  }
+
   return <ProfileSection userId={id} userDetail={userDetail} />;
 }

--- a/src/app/user/[id]/page.tsx
+++ b/src/app/user/[id]/page.tsx
@@ -1,9 +1,12 @@
 import ProfileSection from '@/components/Profile/ProfileSection';
+import { UserDetail } from '@/types/types';
+import { getUserDetail } from '@/utils/getUserDetail';
 
 interface Props {
   params: { id: string };
 }
 
-export default function UserProfilePage({ params: { id } }: Props) {
-  return <ProfileSection userId={id} />;
+export default async function UserProfilePage({ params: { id } }: Props) {
+  const userDetail: UserDetail = await getUserDetail(id);
+  return <ProfileSection userId={id} userDetail={userDetail} />;
 }

--- a/src/components/Card/ProductCard/index.tsx
+++ b/src/components/Card/ProductCard/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import Link from 'next/link';
 import classNames from 'classnames/bind';
 import styles from './ProductCard.module.scss';
 import { ProductListType } from '@/types/types';
@@ -14,7 +15,7 @@ interface Props {
 
 export default function ProductCard({ productItem }: Props) {
   return (
-    <div className={cx('wrapper')}>
+    <Link href={`/product/${productItem.id}`} className={cx('wrapper')}>
       <div className={cx('container')}>
         <div className={cx('product-thumbnail-box')}>
           <Image
@@ -62,6 +63,6 @@ export default function ProductCard({ productItem }: Props) {
           </div>
         </div>
       </div>
-    </div>
+    </Link>
   );
 }

--- a/src/components/Card/ProductCard/index.tsx
+++ b/src/components/Card/ProductCard/index.tsx
@@ -20,7 +20,11 @@ export default function ProductCard({ productItem }: Props) {
           <Image
             fill
             sizes='(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw'
-            src={productItem.image}
+            src={
+              productItem.image.includes('example')
+                ? '/images/profile-image.png'
+                : productItem.image
+            }
             alt='product-image'
             style={{ objectFit: 'contain' }}
             onError={(e) => handleErrorImage(e)}

--- a/src/components/Card/ProductCard/index.tsx
+++ b/src/components/Card/ProductCard/index.tsx
@@ -1,7 +1,10 @@
+'use client';
+
 import Image from 'next/image';
 import classNames from 'classnames/bind';
 import styles from './ProductCard.module.scss';
 import { ProductListType } from '@/types/types';
+import handleErrorImage from '@/utils/handleErrorImage';
 
 const cx = classNames.bind(styles);
 
@@ -20,6 +23,7 @@ export default function ProductCard({ productItem }: Props) {
             src={productItem.image}
             alt='product-image'
             style={{ objectFit: 'contain' }}
+            onError={(e) => handleErrorImage(e)}
           />
         </div>
         <div className={cx('product-description')}>

--- a/src/components/Card/ProductCard/index.tsx
+++ b/src/components/Card/ProductCard/index.tsx
@@ -47,7 +47,9 @@ export default function ProductCard({ productItem }: Props) {
                 height={16}
                 className={cx('star-icon')}
               />
-              <span className={cx('star-rating')}>{productItem.rating}</span>
+              <span className={cx('star-rating')}>
+                {Number(productItem.rating.toFixed(1))}
+              </span>
             </div>
           </div>
         </div>

--- a/src/components/Card/ProfileCard/ProfileCard.module.scss
+++ b/src/components/Card/ProfileCard/ProfileCard.module.scss
@@ -1,6 +1,8 @@
 @import '/src/styles/main.scss';
 
 .wrapper {
+  position: relative;
+  z-index: 2;
   width: 340px;
   border-radius: 12px;
   border: 1px solid $border;
@@ -21,7 +23,7 @@
   position: absolute;
   z-index: 0;
   top: -160px;
-  left: -300px;
+  left: -400px;
   width: 800px;
   height: 800px;
   opacity: 0.15;

--- a/src/components/Card/ProfileCard/ProfileCard.module.scss
+++ b/src/components/Card/ProfileCard/ProfileCard.module.scss
@@ -16,6 +16,28 @@
   }
 }
 
+.blur-image {
+  border-radius: 50%;
+  position: absolute;
+  z-index: 0;
+  top: -160px;
+  left: -300px;
+  width: 800px;
+  height: 800px;
+  opacity: 0.15;
+  filter: blur(100px);
+  @include tablet {
+    width: 580px;
+    height: 580px;
+    top: 0;
+    left: 0;
+  }
+  @include mobile {
+    width: 300px;
+    height: 300px;
+  }
+}
+
 .container {
   @include inline-flexbox;
   flex-direction: column;
@@ -95,6 +117,8 @@
 }
 
 .user-follow-box {
+  position: relative;
+  z-index: 1;
   @include flexbox($align: start);
   gap: 50px;
   @include tablet {
@@ -149,6 +173,8 @@
 }
 
 .button-box {
+  position: relative;
+  z-index: 1;
   @include column-flexbox;
   width: 100%;
   gap: 20px;

--- a/src/components/Card/ProfileCard/ProfileCard.module.scss
+++ b/src/components/Card/ProfileCard/ProfileCard.module.scss
@@ -17,7 +17,7 @@
 }
 
 .container {
-  @include inline-flexbox();
+  @include inline-flexbox;
   flex-direction: column;
   gap: 40px;
   @include tablet {
@@ -26,7 +26,7 @@
     flex-shrink: 0;
   }
   @include mobile {
-    @include column-flexbox();
+    @include column-flexbox;
     width: 295px;
     gap: 30px;
     flex-shrink: 0;
@@ -106,7 +106,7 @@
 }
 
 .follow {
-  @include column-flexbox();
+  @include column-flexbox;
   gap: 10px;
   cursor: pointer;
 }
@@ -145,5 +145,17 @@
   }
   @include mobile {
     height: 48px;
+  }
+}
+
+.button-box {
+  @include column-flexbox;
+  width: 100%;
+  gap: 20px;
+  @include tablet {
+    gap: 15px;
+  }
+  @include mobile {
+    gap: 10px;
   }
 }

--- a/src/components/Card/ProfileCard/ProfileCard.module.scss
+++ b/src/components/Card/ProfileCard/ProfileCard.module.scss
@@ -31,8 +31,8 @@
   @include tablet {
     width: 580px;
     height: 580px;
-    top: 0;
-    left: 0;
+    top: -40px;
+    left: -120px;
   }
   @include mobile {
     width: 300px;

--- a/src/components/Card/ProfileCard/ProfileCard.module.scss
+++ b/src/components/Card/ProfileCard/ProfileCard.module.scss
@@ -28,6 +28,7 @@
   height: 800px;
   opacity: 0.15;
   filter: blur(100px);
+  pointer-events: none;
   @include tablet {
     width: 580px;
     height: 580px;
@@ -70,6 +71,8 @@
 }
 
 .user-information {
+  position: relative;
+  z-index: 1;
   @include column-flexbox();
   width: 300px;
   gap: 20px;

--- a/src/components/Card/ProfileCard/index.tsx
+++ b/src/components/Card/ProfileCard/index.tsx
@@ -2,6 +2,7 @@
 
 import classNames from 'classnames/bind';
 import Image from 'next/image';
+import { usePathname } from 'next/navigation';
 import styles from './ProfileCard.module.scss';
 import Button from '@/components/Button';
 import { UserDetail } from '@/types/types';
@@ -19,6 +20,7 @@ interface Props {
 export type ModalType = 'followers' | 'followees';
 
 export default function ProfileCard({ userDetail, userId }: Props) {
+  const pathname = usePathname();
   const { isOpened, followData, modalType, handleToggleModal } =
     useUserFollowData(userId);
 
@@ -66,7 +68,16 @@ export default function ProfileCard({ userDetail, userId }: Props) {
             <span className={cx('text')}>팔로잉</span>
           </div>
         </div>
-        <Button category='primary'>팔로우</Button>
+        <div className={cx('button-box')}>
+          {pathname === '/mypage' ? (
+            <>
+              <Button category='primary'>프로필 편집</Button>
+              <Button category='tertiary'>로그아웃</Button>
+            </>
+          ) : (
+            <Button category='primary'>팔로우</Button>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/components/Card/ProfileCard/index.tsx
+++ b/src/components/Card/ProfileCard/index.tsx
@@ -10,6 +10,7 @@ import ProfileFollowModal from '@/components/Modal/ProfileFollowModal';
 import useUserFollowData from '@/hooks/useUserFollowData';
 import logout from '@/utils/logout';
 import handleErrorImage from '@/utils/handleErrorImage';
+import EditProfile from '@/components/Modal/EditProfile';
 
 const cx = classNames.bind(styles);
 
@@ -20,7 +21,7 @@ interface Props {
   token: string;
 }
 
-export type ModalType = 'followers' | 'followees';
+export type ModalType = 'followers' | 'followees' | 'edit';
 
 export default function ProfileCard({
   userDetail,
@@ -52,11 +53,15 @@ export default function ProfileCard({
       />
       {isOpened ? (
         <ModalWrapper>
-          <ProfileFollowModal
-            data={followData}
-            modalType={modalType}
-            userName={userDetail.nickname}
-          />
+          {modalType === 'edit' ? (
+            <EditProfile />
+          ) : (
+            <ProfileFollowModal
+              data={followData}
+              modalType={modalType}
+              userName={userDetail.nickname}
+            />
+          )}
         </ModalWrapper>
       ) : null}
       <div className={cx('container')}>
@@ -92,7 +97,12 @@ export default function ProfileCard({
         <div className={cx('button-box')}>
           {pathname === '/mypage' ? (
             <>
-              <Button category='primary'>프로필 편집</Button>
+              <Button
+                category='primary'
+                onClick={() => handleToggleModal('edit')}
+              >
+                프로필 편집
+              </Button>
               <Button category='tertiary' onClick={() => logout()}>
                 로그아웃
               </Button>

--- a/src/components/Card/ProfileCard/index.tsx
+++ b/src/components/Card/ProfileCard/index.tsx
@@ -2,7 +2,6 @@
 
 import classNames from 'classnames/bind';
 import Image from 'next/image';
-import { usePathname } from 'next/navigation';
 import styles from './ProfileCard.module.scss';
 import Button from '@/components/Button';
 import { UserDetail } from '@/types/types';
@@ -17,14 +16,29 @@ const cx = classNames.bind(styles);
 interface Props {
   userDetail: UserDetail;
   userId: string;
+  isLoggedIn: boolean;
+  token: string;
 }
 
 export type ModalType = 'followers' | 'followees';
 
-export default function ProfileCard({ userDetail, userId }: Props) {
-  const pathname = usePathname();
-  const { isOpened, followData, modalType, handleToggleModal } =
-    useUserFollowData(userId);
+export default function ProfileCard({
+  userDetail,
+  userId,
+  isLoggedIn,
+  token,
+}: Props) {
+  const {
+    pathname,
+    followMutation,
+    unfollowMutation,
+    isOpened,
+    followData,
+    modalType,
+    handleToggleModal,
+    handleClickFollow,
+    handleClickUnFollow,
+  } = useUserFollowData(userId, token, isLoggedIn);
 
   return (
     <div className={cx('wrapper')}>
@@ -84,7 +98,17 @@ export default function ProfileCard({ userDetail, userId }: Props) {
               </Button>
             </>
           ) : (
-            <Button category='primary'>팔로우</Button>
+            <Button
+              category={userDetail.isFollowing ? 'tertiary' : 'primary'}
+              onClick={
+                userDetail.isFollowing
+                  ? (e) => handleClickUnFollow(e)
+                  : (e) => handleClickFollow(e)
+              }
+              disabled={followMutation.isPending || unfollowMutation.isPending}
+            >
+              {userDetail.isFollowing ? '팔로우 취소' : '팔로우'}
+            </Button>
           )}
         </div>
       </div>

--- a/src/components/Card/ProfileCard/index.tsx
+++ b/src/components/Card/ProfileCard/index.tsx
@@ -10,6 +10,7 @@ import ModalWrapper from '@/components/Modal/ModalWrapper';
 import ProfileFollowModal from '@/components/Modal/ProfileFollowModal';
 import useUserFollowData from '@/hooks/useUserFollowData';
 import logout from '@/utils/logout';
+import handleErrorImage from '@/utils/handleErrorImage';
 
 const cx = classNames.bind(styles);
 
@@ -33,10 +34,7 @@ export default function ProfileCard({ userDetail, userId }: Props) {
         width={180}
         height={180}
         className={cx('blur-image')}
-        onError={(e) => {
-          const target = e.target as HTMLImageElement;
-          target.src = '/images/profile-image.png';
-        }}
+        onError={(e) => handleErrorImage(e)}
       />
       {isOpened ? (
         <ModalWrapper>
@@ -54,10 +52,7 @@ export default function ProfileCard({ userDetail, userId }: Props) {
           width={180}
           height={180}
           className={cx('profile-image')}
-          onError={(e) => {
-            const target = e.target as HTMLImageElement;
-            target.src = '/images/profile-image.png';
-          }}
+          onError={(e) => handleErrorImage(e)}
         />
         <div className={cx('user-information')}>
           <span className={cx('user-name')}>{userDetail.nickname}</span>

--- a/src/components/Card/ProfileCard/index.tsx
+++ b/src/components/Card/ProfileCard/index.tsx
@@ -27,6 +27,17 @@ export default function ProfileCard({ userDetail, userId }: Props) {
 
   return (
     <div className={cx('wrapper')}>
+      <Image
+        src={userDetail.image || '/images/profile-image.png'}
+        alt='profile-image'
+        width={180}
+        height={180}
+        className={cx('blur-image')}
+        onError={(e) => {
+          const target = e.target as HTMLImageElement;
+          target.src = '/images/profile-image.png';
+        }}
+      />
       {isOpened ? (
         <ModalWrapper>
           <ProfileFollowModal

--- a/src/components/Card/ProfileCard/index.tsx
+++ b/src/components/Card/ProfileCard/index.tsx
@@ -9,6 +9,7 @@ import { UserDetail } from '@/types/types';
 import ModalWrapper from '@/components/Modal/ModalWrapper';
 import ProfileFollowModal from '@/components/Modal/ProfileFollowModal';
 import useUserFollowData from '@/hooks/useUserFollowData';
+import logout from '@/utils/logout';
 
 const cx = classNames.bind(styles);
 
@@ -72,7 +73,9 @@ export default function ProfileCard({ userDetail, userId }: Props) {
           {pathname === '/mypage' ? (
             <>
               <Button category='primary'>프로필 편집</Button>
-              <Button category='tertiary'>로그아웃</Button>
+              <Button category='tertiary' onClick={() => logout()}>
+                로그아웃
+              </Button>
             </>
           ) : (
             <Button category='primary'>팔로우</Button>

--- a/src/components/Input/ImageInput/ImageInput.module.scss
+++ b/src/components/Input/ImageInput/ImageInput.module.scss
@@ -1,0 +1,38 @@
+@import '/src/styles/main.scss';
+
+.input-label {
+  @include flexbox($align: start);
+  width: 160px;
+  height: 160px;
+  padding: 63px;
+  gap: 10px;
+  border-radius: 8px;
+  border: 1px solid $border;
+  background: $comp-bg;
+  cursor: pointer;
+  @include tablet {
+    width: 135px;
+    height: 135px;
+    padding: 55px;
+  }
+  @include mobile {
+    width: 140px;
+    height: 140px;
+    padding: 58px;
+  }
+}
+
+.add-photo-icon {
+  @include tablet {
+    width: 25px;
+    height: 25px;
+  }
+  @include mobile {
+    width: 24px;
+    height: 24px;
+  }
+}
+
+.input {
+  display: none;
+}

--- a/src/components/Input/ImageInput/index.tsx
+++ b/src/components/Input/ImageInput/index.tsx
@@ -1,0 +1,22 @@
+import Image from 'next/image';
+import classNames from 'classnames/bind';
+import styles from './ImageInput.module.scss';
+
+const cx = classNames.bind(styles);
+
+export default function ImageInput() {
+  return (
+    <>
+      <label className={cx('input-label')} htmlFor='profile-image'>
+        <Image
+          src={'/images/add-photo-icon.svg'}
+          alt='add-photo-icon'
+          width={34}
+          height={34}
+          className={cx('add-photo-icon')}
+        />
+      </label>
+      <input type='file' className={cx('input')} id='profile-image' />
+    </>
+  );
+}

--- a/src/components/Input/TextFieldInput/TextFieldInput.module.scss
+++ b/src/components/Input/TextFieldInput/TextFieldInput.module.scss
@@ -15,9 +15,11 @@
 
   @include tablet {
     height: 60px;
+    line-height: 22px;
   }
 
   @include mobile {
+    font-size: 14px;
     height: 55px;
   }
 }

--- a/src/components/Input/TextFieldInput/TextFieldInput.module.scss
+++ b/src/components/Input/TextFieldInput/TextFieldInput.module.scss
@@ -1,0 +1,29 @@
+@import '/src/styles/main.scss';
+
+.input {
+  width: 100%;
+  height: 70px;
+  padding: 23px 20px;
+  background-color: $comp-bg;
+  border-radius: 8px;
+  border: 1px solid $border;
+  color: $primary;
+
+  &:focus {
+    border-color: $main_indigo;
+  }
+
+  @include tablet {
+    height: 60px;
+  }
+
+  @include mobile {
+    height: 55px;
+  }
+}
+
+.error {
+  font-size: 13px;
+  font-weight: 100;
+  color: $tertiary;
+}

--- a/src/components/Input/TextFieldInput/index.tsx
+++ b/src/components/Input/TextFieldInput/index.tsx
@@ -1,0 +1,28 @@
+import { ChangeEvent, InputHTMLAttributes } from 'react';
+import classNames from 'classnames/bind';
+import styles from './TextFieldInput.module.scss';
+
+const cx = classNames.bind(styles);
+
+interface Props extends InputHTMLAttributes<HTMLInputElement> {
+  value: string;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  onBlur: () => void;
+}
+
+export default function TextFieldInput({
+  value,
+  onChange,
+  onBlur,
+  ...rest
+}: Props) {
+  return (
+    <input
+      className={cx('input')}
+      value={value}
+      onBlur={onBlur}
+      onChange={onChange}
+      {...rest}
+    />
+  );
+}

--- a/src/components/Modal/EditProfile/EditProfile.module.scss
+++ b/src/components/Modal/EditProfile/EditProfile.module.scss
@@ -1,0 +1,1 @@
+@import '/src/styles/main.scss';

--- a/src/components/Modal/EditProfile/EditProfile.module.scss
+++ b/src/components/Modal/EditProfile/EditProfile.module.scss
@@ -10,6 +10,7 @@
     height: 548px;
   }
   @include mobile {
+    gap: 20px;
     width: 295px;
     height: 553px;
   }

--- a/src/components/Modal/EditProfile/EditProfile.module.scss
+++ b/src/components/Modal/EditProfile/EditProfile.module.scss
@@ -1,1 +1,32 @@
 @import '/src/styles/main.scss';
+
+.wrapper {
+  @include column-flexbox($align: start);
+  gap: 40px;
+  width: 540px;
+  height: 604px;
+  @include tablet {
+    width: 510px;
+    height: 548px;
+  }
+  @include mobile {
+    width: 295px;
+    height: 553px;
+  }
+}
+
+.edit-profile-form {
+  @include column-flexbox($align: start);
+  gap: 20px;
+  width: 100%;
+}
+
+.title {
+  color: $primary;
+  font-size: 24px;
+  font-weight: 600;
+  @include tablet {
+    font-size: 20px;
+    line-height: 28px;
+  }
+}

--- a/src/components/Modal/EditProfile/index.tsx
+++ b/src/components/Modal/EditProfile/index.tsx
@@ -4,6 +4,7 @@ import { ChangeEvent, useState } from 'react';
 import classNames from 'classnames/bind';
 import styles from './EditProfile.module.scss';
 import Button from '@/components/Button';
+import TextFieldInput from '@/components/Input/TextFieldInput';
 
 const cx = classNames.bind(styles);
 
@@ -12,13 +13,21 @@ export default function EditProfile() {
   const handleChangeUserName = (e: ChangeEvent<HTMLInputElement>) => {
     setUserName(e.target.value);
   };
+  const handleOnBlur = () => {
+    console.log('blur');
+  };
 
   return (
     <div className={cx('wrapper')}>
       <span className={cx('title')}>프로필 편집</span>
       <form className={cx('edit-profile-form')}>
         <input type='file' />
-        <input type='text' value={userName} onChange={handleChangeUserName} />
+        <TextFieldInput
+          onBlur={handleOnBlur}
+          value={userName}
+          onChange={handleChangeUserName}
+          placeholder='닉네임을 입력해 주세요'
+        />
       </form>
       <Button category='primary'>저장하기</Button>
     </div>

--- a/src/components/Modal/EditProfile/index.tsx
+++ b/src/components/Modal/EditProfile/index.tsx
@@ -1,0 +1,8 @@
+import classNames from 'classnames/bind';
+import styles from './EditProfile.module.scss';
+
+const cx = classNames.bind(styles);
+
+export default function EditProfile() {
+  return <div className={cx('wrapper')}>EditProfile</div>;
+}

--- a/src/components/Modal/EditProfile/index.tsx
+++ b/src/components/Modal/EditProfile/index.tsx
@@ -1,8 +1,26 @@
+'use client';
+
+import { ChangeEvent, useState } from 'react';
 import classNames from 'classnames/bind';
 import styles from './EditProfile.module.scss';
+import Button from '@/components/Button';
 
 const cx = classNames.bind(styles);
 
 export default function EditProfile() {
-  return <div className={cx('wrapper')}>EditProfile</div>;
+  const [userName, setUserName] = useState('');
+  const handleChangeUserName = (e: ChangeEvent<HTMLInputElement>) => {
+    setUserName(e.target.value);
+  };
+
+  return (
+    <div className={cx('wrapper')}>
+      <span className={cx('title')}>프로필 편집</span>
+      <form className={cx('edit-profile-form')}>
+        <input type='file' />
+        <input type='text' value={userName} onChange={handleChangeUserName} />
+      </form>
+      <Button category='primary'>저장하기</Button>
+    </div>
+  );
 }

--- a/src/components/Modal/EditProfile/index.tsx
+++ b/src/components/Modal/EditProfile/index.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames/bind';
 import styles from './EditProfile.module.scss';
 import Button from '@/components/Button';
 import TextFieldInput from '@/components/Input/TextFieldInput';
+import ImageInput from '@/components/Input/ImageInput';
 
 const cx = classNames.bind(styles);
 
@@ -21,7 +22,7 @@ export default function EditProfile() {
     <div className={cx('wrapper')}>
       <span className={cx('title')}>프로필 편집</span>
       <form className={cx('edit-profile-form')}>
-        <input type='file' />
+        <ImageInput />
         <TextFieldInput
           onBlur={handleOnBlur}
           value={userName}

--- a/src/components/Modal/FollowUserList/index.tsx
+++ b/src/components/Modal/FollowUserList/index.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames/bind';
 import styles from './FollowUserList.module.scss';
 import { User } from '@/types/types';
 import { ModalType } from '@/components/Card/ProfileCard';
+import handleErrorImage from '@/utils/handleErrorImage';
 
 const cx = classNames.bind(styles);
 
@@ -20,10 +21,7 @@ export default function FollowUserList({ user }: Props) {
         width={52}
         height={52}
         className={cx('user-image')}
-        onError={(e) => {
-          const target = e.target as HTMLImageElement;
-          target.src = '/images/profile-image.png';
-        }}
+        onError={(e) => handleErrorImage(e)}
       />
       <span className={cx('user-name')}>{user.nickname}</span>
     </div>

--- a/src/components/Modal/FollowUserList/index.tsx
+++ b/src/components/Modal/FollowUserList/index.tsx
@@ -1,9 +1,11 @@
 import Image from 'next/image';
 import classNames from 'classnames/bind';
+import Link from 'next/link';
 import styles from './FollowUserList.module.scss';
 import { User } from '@/types/types';
 import { ModalType } from '@/components/Card/ProfileCard';
 import handleErrorImage from '@/utils/handleErrorImage';
+import { useModalStore } from '../../../../providers/ModalStoreProvider';
 
 const cx = classNames.bind(styles);
 
@@ -13,17 +15,20 @@ interface Props {
 }
 
 export default function FollowUserList({ user }: Props) {
+  const { toggleModal } = useModalStore((state) => state);
   return (
-    <div className={cx('user-information')}>
-      <Image
-        src={user.image || '/images/profile-image.png'}
-        alt='user-image'
-        width={52}
-        height={52}
-        className={cx('user-image')}
-        onError={(e) => handleErrorImage(e)}
-      />
-      <span className={cx('user-name')}>{user.nickname}</span>
-    </div>
+    <Link href={`/user/${user.id}`} onClick={toggleModal}>
+      <div className={cx('user-information')}>
+        <Image
+          src={user.image || '/images/profile-image.png'}
+          alt='user-image'
+          width={52}
+          height={52}
+          className={cx('user-image')}
+          onError={(e) => handleErrorImage(e)}
+        />
+        <span className={cx('user-name')}>{user.nickname}</span>
+      </div>
+    </Link>
   );
 }

--- a/src/components/Profile/ProfileProductCardList/ProfileProductCardList.module.scss
+++ b/src/components/Profile/ProfileProductCardList/ProfileProductCardList.module.scss
@@ -1,0 +1,17 @@
+@import '/src/styles/main.scss';
+
+.product-card-container {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 20px;
+  width: 100%;
+  justify-items: center;
+  @include tablet {
+    grid-template-columns: 1fr 1fr;
+    gap: 15px;
+  }
+  @include mobile {
+    grid-template-columns: 1fr 1fr;
+    gap: 15px;
+  }
+}

--- a/src/components/Profile/ProfileProductCardList/ProfileProductCardList.module.scss
+++ b/src/components/Profile/ProfileProductCardList/ProfileProductCardList.module.scss
@@ -15,3 +15,7 @@
     gap: 15px;
   }
 }
+
+.product-link {
+  width: 100%;
+}

--- a/src/components/Profile/ProfileProductCardList/ProfileProductCardList.module.scss
+++ b/src/components/Profile/ProfileProductCardList/ProfileProductCardList.module.scss
@@ -15,7 +15,3 @@
     gap: 15px;
   }
 }
-
-.product-link {
-  width: 100%;
-}

--- a/src/components/Profile/ProfileProductCardList/index.tsx
+++ b/src/components/Profile/ProfileProductCardList/index.tsx
@@ -1,0 +1,20 @@
+import classNames from 'classnames/bind';
+import styles from './ProfileProductCardList.module.scss';
+import ProductCard from '@/components/Card/ProductCard';
+import { ProductListType } from '@/types/types';
+
+const cx = classNames.bind(styles);
+
+interface Props {
+  productCardItem: ProductListType[] | undefined;
+}
+
+export default function ProfileProductCardList({ productCardItem }: Props) {
+  return (
+    <div className={cx('product-card-container')}>
+      {productCardItem?.map((product) => {
+        return <ProductCard productItem={product} key={product.id} />;
+      })}
+    </div>
+  );
+}

--- a/src/components/Profile/ProfileProductCardList/index.tsx
+++ b/src/components/Profile/ProfileProductCardList/index.tsx
@@ -1,5 +1,4 @@
 import classNames from 'classnames/bind';
-import Link from 'next/link';
 import styles from './ProfileProductCardList.module.scss';
 import ProductCard from '@/components/Card/ProductCard';
 import { ProductListType } from '@/types/types';
@@ -14,15 +13,7 @@ export default function ProfileProductCardList({ productCardItem }: Props) {
   return (
     <div className={cx('product-card-container')}>
       {productCardItem?.map((product) => {
-        return (
-          <Link
-            href={`/product/${product.id}`}
-            className={cx('product-link')}
-            key={product.id}
-          >
-            <ProductCard productItem={product} />
-          </Link>
-        );
+        return <ProductCard productItem={product} key={product.id} />;
       })}
     </div>
   );

--- a/src/components/Profile/ProfileProductCardList/index.tsx
+++ b/src/components/Profile/ProfileProductCardList/index.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames/bind';
+import Link from 'next/link';
 import styles from './ProfileProductCardList.module.scss';
 import ProductCard from '@/components/Card/ProductCard';
 import { ProductListType } from '@/types/types';
@@ -13,7 +14,15 @@ export default function ProfileProductCardList({ productCardItem }: Props) {
   return (
     <div className={cx('product-card-container')}>
       {productCardItem?.map((product) => {
-        return <ProductCard productItem={product} key={product.id} />;
+        return (
+          <Link
+            href={`/product/${product.id}`}
+            className={cx('product-link')}
+            key={product.id}
+          >
+            <ProductCard productItem={product} />
+          </Link>
+        );
       })}
     </div>
   );

--- a/src/components/Profile/ProfileProductPanel/ProfileProductPanel.module.scss
+++ b/src/components/Profile/ProfileProductPanel/ProfileProductPanel.module.scss
@@ -7,6 +7,8 @@
 }
 
 .title-container {
+  position: relative;
+  z-index: 1;
   @include flexbox;
   gap: 40px;
 }
@@ -15,44 +17,11 @@
   color: $tertiary;
   font-size: 20px;
   font-weight: 600;
+  cursor: pointer;
   @include tablet {
     font-size: 18px;
   }
   @include mobile {
     font-size: 18px;
-  }
-}
-
-.product-card-container {
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  gap: 20px;
-  width: 100%;
-  justify-items: center;
-  @include tablet {
-    grid-template-columns: 1fr 1fr;
-    gap: 15px;
-  }
-  @include mobile {
-    grid-template-columns: 1fr 1fr;
-    gap: 15px;
-  }
-}
-
-// 임시 카드 컴포넌트 완성되면 삭제
-.product-card {
-  display: flex;
-  width: 100%;
-  max-width: 300px;
-  padding: 8px 8px 25px 8px;
-  height: 308px;
-  border-radius: 12px;
-  border: 1px solid var(--black-black_353542, #353542);
-  background: var(--black-black_252530, #252530);
-  @include tablet {
-    height: 256px;
-  }
-  @include mobile {
-    height: 183px;
   }
 }

--- a/src/components/Profile/ProfileProductPanel/ProfileProductPanel.module.scss
+++ b/src/components/Profile/ProfileProductPanel/ProfileProductPanel.module.scss
@@ -24,4 +24,8 @@
   @include mobile {
     font-size: 18px;
   }
+
+  &.selected {
+    color: $primary;
+  }
 }

--- a/src/components/Profile/ProfileProductPanel/index.tsx
+++ b/src/components/Profile/ProfileProductPanel/index.tsx
@@ -19,25 +19,35 @@ export type UserProductCategory =
 export default function ProfileProductPanel({ userId }: Props) {
   // TODO(이시열): 모바일 사이즈 타이틀 드롭다운
   // react-query: 무한스크롤
-  const { productCardItem, handleClickTitle } = useUserProductData(userId);
+  const { userProductCategory, productCardItem, handleClickTitle } =
+    useUserProductData(userId);
 
   return (
     <section className={cx('wrapper')}>
       <span className={cx('title-container')}>
         <span
-          className={cx('title')}
+          className={cx(
+            'title',
+            userProductCategory === 'reviewed-products' ? 'selected' : '',
+          )}
           onClick={() => handleClickTitle('reviewed-products')}
         >
           리뷰 남긴 상품
         </span>
         <span
-          className={cx('title')}
+          className={cx(
+            'title',
+            userProductCategory === 'created-products' ? 'selected' : '',
+          )}
           onClick={() => handleClickTitle('created-products')}
         >
           등록한 상품
         </span>
         <span
-          className={cx('title')}
+          className={cx(
+            'title',
+            userProductCategory === 'favorite-products' ? 'selected' : '',
+          )}
           onClick={() => handleClickTitle('favorite-products')}
         >
           찜한 상품

--- a/src/components/Profile/ProfileProductPanel/index.tsx
+++ b/src/components/Profile/ProfileProductPanel/index.tsx
@@ -1,61 +1,86 @@
+'use client';
+
+import { useLayoutEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import classNames from 'classnames/bind';
 import styles from './ProfileProductPanel.module.scss';
-import ProductCard from '@/components/Card/ProductCard';
-import { ProductListType } from '@/types/types';
+import { ProductListType, SearchProductResponse } from '@/types/types';
+import getUserProduct from '@/utils/getUserProduct';
+import ProfileProductCardList from '../ProfileProductCardList';
 
 const cx = classNames.bind(styles);
 
-// 임시 product 데이터
-const productItem1: ProductListType = {
-  updatedAt: '2024-04-23T04:03:04.169Z',
-  createdAt: '2024-04-23T04:03:04.169Z',
-  writerId: 1,
-  categoryId: 1,
-  favoriteCount: 0,
-  reviewCount: 0,
-  rating: 0,
-  image: '/images/product-example.png',
-  name: '제품 이름은 1자 부터 20자 입니다',
-  id: 1,
-};
+interface Props {
+  userId: string;
+}
 
-const productItem2: ProductListType = {
-  updatedAt: '2024-04-23T04:03:04.169Z',
-  createdAt: '2024-04-23T04:03:04.169Z',
-  writerId: 1,
-  categoryId: 1,
-  favoriteCount: 0,
-  reviewCount: 0,
-  rating: 0,
-  image: '/images/product-example.png',
-  name: '짧은 제품 이름',
-  id: 1,
-};
+export type UserProductCategory =
+  | 'reviewed-products'
+  | 'created-products'
+  | 'favorite-products';
 
-export default function ProfileProductPanel() {
+export default function ProfileProductPanel({ userId }: Props) {
   // TODO(이시열): 타이틀 선택(정렬), 테블릿, 모바일 사이즈 타이틀 드롭다운
   // react-query: 리뷰 남긴 상품, 등록한 상품, 찜한 상품 불러오기, 무한스크롤
+  const [userProductCategory, setUserProductCategory] =
+    useState<UserProductCategory>('reviewed-products');
+  const [productCardItem, setProductCardItem] = useState<ProductListType[]>();
+
+  const handleClickTitle = (title: UserProductCategory) => {
+    setUserProductCategory(title);
+  };
+
+  const { data: createdProduct } = useQuery<SearchProductResponse>({
+    queryKey: ['user-reviewed-products', userId],
+    queryFn: () => getUserProduct(userId, 'reviewed-products'),
+    staleTime: 60 * 3 * 1000,
+  });
+  const { data: reviewedProduct } = useQuery<SearchProductResponse>({
+    queryKey: ['user-created-products', userId],
+    queryFn: () => getUserProduct(userId, 'created-products'),
+    staleTime: 60 * 3 * 1000,
+  });
+  const { data: favoriteProduct } = useQuery<SearchProductResponse>({
+    queryKey: ['user-favorite-products', userId],
+    queryFn: () => getUserProduct(userId, 'favorite-products'),
+    staleTime: 60 * 3 * 1000,
+  });
+
+  useLayoutEffect(() => {
+    if (userProductCategory === 'reviewed-products') {
+      setProductCardItem(reviewedProduct?.list);
+    }
+    if (userProductCategory === 'created-products') {
+      setProductCardItem(createdProduct?.list);
+    }
+    if (userProductCategory === 'favorite-products') {
+      setProductCardItem(favoriteProduct?.list);
+    }
+  }, [userProductCategory, reviewedProduct, createdProduct, favoriteProduct]);
+
   return (
     <section className={cx('wrapper')}>
       <span className={cx('title-container')}>
-        <span className={cx('title')}>리뷰 남긴 상품</span>
-        <span className={cx('title')}>등록한 상품</span>
-        <span className={cx('title')}>찜한 상품</span>
+        <span
+          className={cx('title')}
+          onClick={() => handleClickTitle('reviewed-products')}
+        >
+          리뷰 남긴 상품
+        </span>
+        <span
+          className={cx('title')}
+          onClick={() => handleClickTitle('created-products')}
+        >
+          등록한 상품
+        </span>
+        <span
+          className={cx('title')}
+          onClick={() => handleClickTitle('favorite-products')}
+        >
+          찜한 상품
+        </span>
       </span>
-      <div className={cx('product-card-container')}>
-        {/* 임시 카드 */}
-        <ProductCard productItem={productItem1} />
-        <ProductCard productItem={productItem2} />
-        <ProductCard productItem={productItem1} />
-        <ProductCard productItem={productItem1} />
-        <ProductCard productItem={productItem1} />
-        <ProductCard productItem={productItem2} />
-        <ProductCard productItem={productItem2} />
-        <ProductCard productItem={productItem1} />
-        <ProductCard productItem={productItem2} />
-        <ProductCard productItem={productItem2} />
-        <ProductCard productItem={productItem1} />
-      </div>
+      <ProfileProductCardList productCardItem={productCardItem} />
     </section>
   );
 }

--- a/src/components/Profile/ProfileProductPanel/index.tsx
+++ b/src/components/Profile/ProfileProductPanel/index.tsx
@@ -1,12 +1,9 @@
 'use client';
 
-import { useLayoutEffect, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
 import classNames from 'classnames/bind';
 import styles from './ProfileProductPanel.module.scss';
-import { ProductListType, SearchProductResponse } from '@/types/types';
-import getUserProduct from '@/utils/getUserProduct';
 import ProfileProductCardList from '../ProfileProductCardList';
+import useUserProductData from '@/hooks/useUserProductData';
 
 const cx = classNames.bind(styles);
 
@@ -20,43 +17,9 @@ export type UserProductCategory =
   | 'favorite-products';
 
 export default function ProfileProductPanel({ userId }: Props) {
-  // TODO(이시열): 타이틀 선택(정렬), 테블릿, 모바일 사이즈 타이틀 드롭다운
-  // react-query: 리뷰 남긴 상품, 등록한 상품, 찜한 상품 불러오기, 무한스크롤
-  const [userProductCategory, setUserProductCategory] =
-    useState<UserProductCategory>('reviewed-products');
-  const [productCardItem, setProductCardItem] = useState<ProductListType[]>();
-
-  const handleClickTitle = (title: UserProductCategory) => {
-    setUserProductCategory(title);
-  };
-
-  const { data: createdProduct } = useQuery<SearchProductResponse>({
-    queryKey: ['user-reviewed-products', userId],
-    queryFn: () => getUserProduct(userId, 'reviewed-products'),
-    staleTime: 60 * 3 * 1000,
-  });
-  const { data: reviewedProduct } = useQuery<SearchProductResponse>({
-    queryKey: ['user-created-products', userId],
-    queryFn: () => getUserProduct(userId, 'created-products'),
-    staleTime: 60 * 3 * 1000,
-  });
-  const { data: favoriteProduct } = useQuery<SearchProductResponse>({
-    queryKey: ['user-favorite-products', userId],
-    queryFn: () => getUserProduct(userId, 'favorite-products'),
-    staleTime: 60 * 3 * 1000,
-  });
-
-  useLayoutEffect(() => {
-    if (userProductCategory === 'reviewed-products') {
-      setProductCardItem(reviewedProduct?.list);
-    }
-    if (userProductCategory === 'created-products') {
-      setProductCardItem(createdProduct?.list);
-    }
-    if (userProductCategory === 'favorite-products') {
-      setProductCardItem(favoriteProduct?.list);
-    }
-  }, [userProductCategory, reviewedProduct, createdProduct, favoriteProduct]);
+  // TODO(이시열): 모바일 사이즈 타이틀 드롭다운
+  // react-query: 무한스크롤
+  const { productCardItem, handleClickTitle } = useUserProductData(userId);
 
   return (
     <section className={cx('wrapper')}>

--- a/src/components/Profile/ProfileSection/ProfileSection.module.scss
+++ b/src/components/Profile/ProfileSection/ProfileSection.module.scss
@@ -26,7 +26,7 @@
 
 .profile-section {
   position: sticky;
-  z-index: 1;
+  z-index: 2;
   top: 50px;
   align-self: start;
   @include tablet {

--- a/src/components/Profile/ProfileSection/ProfileSection.module.scss
+++ b/src/components/Profile/ProfileSection/ProfileSection.module.scss
@@ -12,11 +12,12 @@
 }
 
 .container {
-  @include flexbox;
+  @include flexbox($align: start);
   gap: 60px;
   width: 100%;
   max-width: 1340px;
   @include tablet {
+    align-items: center;
     flex-direction: column;
   }
   @include mobile {

--- a/src/components/Profile/ProfileSection/index.tsx
+++ b/src/components/Profile/ProfileSection/index.tsx
@@ -10,14 +10,26 @@ const cx = classNames.bind(styles);
 interface Props {
   userId: string;
   userDetail: UserDetail;
+  isLoggedIn: boolean;
+  token: string;
 }
 
-export default function ProfileSection({ userId, userDetail }: Props) {
+export default function ProfileSection({
+  userId,
+  userDetail,
+  isLoggedIn,
+  token,
+}: Props) {
   return (
     <main className={cx('wrapper')}>
       <section className={cx('container')}>
         <div className={cx('profile-section')}>
-          <ProfileCard userDetail={userDetail} userId={userId} />
+          <ProfileCard
+            userDetail={userDetail}
+            userId={userId}
+            isLoggedIn={isLoggedIn}
+            token={token}
+          />
         </div>
         <section className={cx('activity-section')}>
           <ActivityDetail userDetail={userDetail} />

--- a/src/components/Profile/ProfileSection/index.tsx
+++ b/src/components/Profile/ProfileSection/index.tsx
@@ -3,17 +3,16 @@ import ProfileProductPanel from '@/components/Profile/ProfileProductPanel';
 import ActivityDetail from '@/components/ActivityDetail';
 import ProfileCard from '@/components/Card/ProfileCard';
 import styles from './ProfileSection.module.scss';
-import getUserDetail from '@/utils/getUserDetail';
 import { UserDetail } from '@/types/types';
 
 const cx = classNames.bind(styles);
 
 interface Props {
   userId: string;
+  userDetail: UserDetail;
 }
 
-export default async function ProfileSection({ userId }: Props) {
-  const userDetail: UserDetail = await getUserDetail(userId);
+export default function ProfileSection({ userId, userDetail }: Props) {
   return (
     <main className={cx('wrapper')}>
       <section className={cx('container')}>

--- a/src/components/Profile/ProfileSection/index.tsx
+++ b/src/components/Profile/ProfileSection/index.tsx
@@ -21,7 +21,7 @@ export default function ProfileSection({ userId, userDetail }: Props) {
         </div>
         <section className={cx('activity-section')}>
           <ActivityDetail userDetail={userDetail} />
-          <ProfileProductPanel />
+          <ProfileProductPanel userId={userId} />
         </section>
       </section>
     </main>

--- a/src/hooks/useUserFollowData.ts
+++ b/src/hooks/useUserFollowData.ts
@@ -1,5 +1,6 @@
-import { useLayoutEffect, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { MouseEvent, useLayoutEffect, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { usePathname, useRouter } from 'next/navigation';
 import { useModalStore } from '../../providers/ModalStoreProvider';
 import { ModalType } from '@/components/Card/ProfileCard';
 import { UserFolloweeList, UserFollowerList } from '@/types/types';
@@ -7,8 +8,16 @@ import {
   getUserFolloweeList,
   getUserFollowerList,
 } from '@/utils/getUserFollowList';
+import followUser from '@/utils/followUser';
 
-const useUserFollowData = (userId: string) => {
+const useUserFollowData = (
+  userId: string,
+  token: string,
+  isLoggedIn: boolean,
+) => {
+  const pathname = usePathname();
+  const route = useRouter();
+  const queryClient = useQueryClient();
   const { isOpened, toggleModal } = useModalStore((state) => state);
   const [modalType, setModalType] = useState<ModalType>('followers');
   const [followData, setFollowData] = useState<
@@ -18,18 +27,74 @@ const useUserFollowData = (userId: string) => {
   const { data: follower } = useQuery<UserFollowerList | UserFolloweeList>({
     queryKey: ['user-follower-list', userId],
     queryFn: () => getUserFollowerList(userId),
-    staleTime: 60 * 5 * 1000,
+    staleTime: 20 * 1000,
   });
   const { data: followee } = useQuery<UserFollowerList | UserFolloweeList>({
     queryKey: ['user-followee-list', userId],
     queryFn: () => getUserFolloweeList(userId),
-    staleTime: 60 * 5 * 1000,
+    staleTime: 20 * 1000,
   });
 
   const handleToggleModal = async (type: ModalType) => {
     setModalType(type);
 
     toggleModal();
+  };
+
+  const followMutation = useMutation({
+    mutationFn: () => followUser(userId, token, 'POST'),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['user-follower-list', userId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['user-followee-list', userId],
+      });
+    },
+  });
+
+  const unfollowMutation = useMutation({
+    mutationFn: () => followUser(userId, token, 'DELETE'),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['user-follower-list', userId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['user-followee-list', userId],
+      });
+    },
+  });
+
+  const handleClickFollow = (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    if (!isLoggedIn) {
+      route.push('/signin');
+      return;
+    }
+    followMutation.mutate(undefined, {
+      onSuccess: () => {
+        route.refresh();
+      },
+      onError: () => {
+        throw new Error('failed to follow');
+      },
+    });
+  };
+
+  const handleClickUnFollow = (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    if (!isLoggedIn) {
+      route.push('/signin');
+      return;
+    }
+    unfollowMutation.mutate(undefined, {
+      onSuccess: () => {
+        route.refresh();
+      },
+      onError: () => {
+        throw new Error('failed to follow');
+      },
+    });
   };
 
   useLayoutEffect(() => {
@@ -41,7 +106,17 @@ const useUserFollowData = (userId: string) => {
     }
   }, [modalType, follower, followee]);
 
-  return { isOpened, followData, modalType, handleToggleModal };
+  return {
+    pathname,
+    followMutation,
+    unfollowMutation,
+    isOpened,
+    followData,
+    modalType,
+    handleToggleModal,
+    handleClickFollow,
+    handleClickUnFollow,
+  };
 };
 
 export default useUserFollowData;

--- a/src/hooks/useUserProductData.ts
+++ b/src/hooks/useUserProductData.ts
@@ -1,0 +1,47 @@
+import { useLayoutEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { UserProductCategory } from '@/components/Profile/ProfileProductPanel';
+import { ProductListType, SearchProductResponse } from '@/types/types';
+import getUserProduct from '@/utils/getUserProduct';
+
+const useUserProductData = (userId: string) => {
+  const [userProductCategory, setUserProductCategory] =
+    useState<UserProductCategory>('reviewed-products');
+  const [productCardItem, setProductCardItem] = useState<ProductListType[]>();
+
+  const handleClickTitle = (title: UserProductCategory) => {
+    setUserProductCategory(title);
+  };
+
+  const { data: reviewedProduct } = useQuery<SearchProductResponse>({
+    queryKey: ['user-reviewed-products', userId],
+    queryFn: () => getUserProduct(userId, 'reviewed-products'),
+    staleTime: 60 * 3 * 1000,
+  });
+  const { data: createdProduct } = useQuery<SearchProductResponse>({
+    queryKey: ['user-created-products', userId],
+    queryFn: () => getUserProduct(userId, 'created-products'),
+    staleTime: 60 * 3 * 1000,
+  });
+  const { data: favoriteProduct } = useQuery<SearchProductResponse>({
+    queryKey: ['user-favorite-products', userId],
+    queryFn: () => getUserProduct(userId, 'favorite-products'),
+    staleTime: 60 * 3 * 1000,
+  });
+
+  useLayoutEffect(() => {
+    if (userProductCategory === 'reviewed-products') {
+      setProductCardItem(reviewedProduct?.list);
+    }
+    if (userProductCategory === 'created-products') {
+      setProductCardItem(createdProduct?.list);
+    }
+    if (userProductCategory === 'favorite-products') {
+      setProductCardItem(favoriteProduct?.list);
+    }
+  }, [userProductCategory, reviewedProduct, createdProduct, favoriteProduct]);
+
+  return { productCardItem, handleClickTitle };
+};
+
+export default useUserProductData;

--- a/src/hooks/useUserProductData.ts
+++ b/src/hooks/useUserProductData.ts
@@ -41,7 +41,7 @@ const useUserProductData = (userId: string) => {
     }
   }, [userProductCategory, reviewedProduct, createdProduct, favoriteProduct]);
 
-  return { productCardItem, handleClickTitle };
+  return { userProductCategory, productCardItem, handleClickTitle };
 };
 
 export default useUserProductData;

--- a/src/utils/followUser.ts
+++ b/src/utils/followUser.ts
@@ -1,0 +1,26 @@
+import { FollowRequestBody } from '@/types/types.ts';
+
+const followUser = async (
+  userId: string,
+  token: string,
+  method: 'POST' | 'DELETE',
+) => {
+  const body: FollowRequestBody = { userId: Number(userId) };
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+  };
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL_HOST}/follow`,
+    {
+      method,
+      headers,
+      body: JSON.stringify(body),
+    },
+  );
+  if (!response.ok) {
+    throw new Error('error to follow');
+  }
+};
+
+export default followUser;

--- a/src/utils/getUserDetail.ts
+++ b/src/utils/getUserDetail.ts
@@ -9,4 +9,18 @@ const getUserDetail = async (id: string) => {
   }
 };
 
-export default getUserDetail;
+const getMyDetail = async (token: string) => {
+  try {
+    const response = await fetch(`${process.env.API_URL_HOST}/users/me`, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const result = await response.json();
+    return result;
+  } catch (error) {
+    console.log(error);
+    return null;
+  }
+};
+
+export { getUserDetail, getMyDetail };

--- a/src/utils/getUserDetail.ts
+++ b/src/utils/getUserDetail.ts
@@ -1,6 +1,15 @@
-const getUserDetail = async (id: string) => {
+const getUserDetail = async (id: string, token?: string) => {
+  const header = token
+    ? {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${token}` },
+      }
+    : {};
   try {
-    const response = await fetch(`${process.env.API_URL_HOST}/users/${id}`);
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL_HOST}/users/${id}`,
+      header,
+    );
     const result = await response.json();
     return result;
   } catch (error) {
@@ -10,10 +19,13 @@ const getUserDetail = async (id: string) => {
 
 const getMyDetail = async (token: string) => {
   try {
-    const response = await fetch(`${process.env.API_URL_HOST}/users/me`, {
-      method: 'GET',
-      headers: { Authorization: `Bearer ${token}` },
-    });
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL_HOST}/users/me`,
+      {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
     const result = await response.json();
     return result;
   } catch (error) {

--- a/src/utils/getUserDetail.ts
+++ b/src/utils/getUserDetail.ts
@@ -4,8 +4,7 @@ const getUserDetail = async (id: string) => {
     const result = await response.json();
     return result;
   } catch (error) {
-    console.log(error);
-    return null;
+    throw new Error('failed to get user data');
   }
 };
 
@@ -18,8 +17,7 @@ const getMyDetail = async (token: string) => {
     const result = await response.json();
     return result;
   } catch (error) {
-    console.log(error);
-    return null;
+    throw new Error('failed to get user data');
   }
 };
 

--- a/src/utils/getUserProduct.ts
+++ b/src/utils/getUserProduct.ts
@@ -1,0 +1,12 @@
+import { UserProductCategory } from '@/components/Profile/ProfileProductPanel';
+import { axiosGet } from './fetchUtils.ts';
+
+const getUserProduct = async (
+  id: string,
+  userProductCategory: UserProductCategory,
+) => {
+  const response = await axiosGet(`users/${id}/${userProductCategory}`);
+  return response;
+};
+
+export default getUserProduct;

--- a/src/utils/handleErrorImage.ts
+++ b/src/utils/handleErrorImage.ts
@@ -1,0 +1,8 @@
+import { SyntheticEvent } from 'react';
+
+const handleErrorImage = (e: SyntheticEvent<HTMLImageElement, Event>) => {
+  const target = e.target as HTMLImageElement;
+  target.src = '/images/profile-image.png';
+};
+
+export default handleErrorImage;

--- a/src/utils/logout.ts
+++ b/src/utils/logout.ts
@@ -1,0 +1,11 @@
+'use server';
+
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+const logout = async () => {
+  cookies().delete('accessToken');
+  redirect('/');
+};
+
+export default logout;


### PR DESCRIPTION
### PR Type

- [x] 기능개발(Feature)
- [ ] 버그수정(Bugfix)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
- 프로필 이미지에 맞춰 배경 블러 처리
- 내 프로필 페이지 구현
- 로그아웃 기능 구현
  - 로그아웃 시 쿠키 삭제 후 메인 페이지로 이동
- 리뷰 남긴 상품, 등록한 상품, 찜한 상품 데이터 불러오기
- 팔로우, 팔로잉 목록 모달에서 유저 클릭시 해당 유저 페이지로 이동

### 추가
----------------------------------------------
- 유저 팔로우/언팔로우 기능 구현
- TextFieldInput, ImageInput 컴포넌트 제작
--------------------------------------------------

### 상세 내용(Describe your changes)
- next.config에 이미지 url 전체 허용을 한것같은데 `example.com` 에 대해서만 오류가 나서, 일단 상품 카드 컴포넌트에서만 오류 처리를 해놨습니다.
- `axiosGet` 함수로 내 정보를 불러오려고 했는데, `"Unauthorized"` 가 나오더라구요. 그래서 일단 `fetch`로 `Bearer token` 헤더 전달해서 구현했습니다.


### 이미지
<img width="1582" alt="스크린샷 2024-04-26 오후 6 37 31" src="https://github.com/Codeit-FE3-Part4-team1-Final/Mogazoa/assets/85405709/dd42dff2-0436-4ad3-be0f-485bc28e732a">
