### PR TITLE
✨ 카카오톡 공유하기/간편로그인/회원가입 기능 구현, 간편로그인(카카오톡) 회원가입을 위한 페이지 제작

### DIFF
--- a/providers/KakaoScript.tsx
+++ b/providers/KakaoScript.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import Script from 'next/script';
+
+function KakaoScript() {
+  const onLoad = () => {
+    window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_API_KEY);
+  };
+
+  return (
+    <Script
+      src='https://developers.kakao.com/sdk/js/kakao.js'
+      async
+      onLoad={onLoad}
+    />
+  );
+}
+
+export default KakaoScript;

--- a/providers/KakaoScript.tsx
+++ b/providers/KakaoScript.tsx
@@ -4,7 +4,7 @@ import Script from 'next/script';
 
 function KakaoScript() {
   const onLoad = () => {
-    window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_API_KEY);
+    window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_JAVASCRIPT_KEY);
   };
 
   return (

--- a/providers/KakaoScript.tsx
+++ b/providers/KakaoScript.tsx
@@ -9,7 +9,9 @@ function KakaoScript() {
 
   return (
     <Script
-      src='https://developers.kakao.com/sdk/js/kakao.js'
+      src='https://t1.kakaocdn.net/kakao_js_sdk/2.7.1/kakao.min.js'
+      integrity='sha384-kDljxUXHaJ9xAb2AzRd59KxjrFjzHa5TAoFQ6GbYTCAG0bjM55XohjjDT7tDDC01'
+      crossOrigin='anonymous'
       async
       onLoad={onLoad}
     />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,14 @@ import NavigationBar from '@/components/NavigationBar';
 import { ModalStoreProvider } from '../../providers/ModalStoreProvider';
 import ProgressBar from '@/components/Loading/Nprogress';
 import Floating from '@/components/Floating';
+import KakaoScript from '../../providers/KakaoScript';
+
+declare global {
+  interface Window {
+    // eslint-disable-next-line
+    Kakao: any;
+  }
+}
 
 export const metadata: Metadata = {
   title: 'Create Next App',
@@ -32,6 +40,7 @@ export default function RootLayout({
           </ModalStoreProvider>
         </ReactQueryProvider>
       </body>
+      <KakaoScript />
     </html>
   );
 }

--- a/src/app/oauth/signup/[provider]/OAuthSignup.module.scss
+++ b/src/app/oauth/signup/[provider]/OAuthSignup.module.scss
@@ -1,0 +1,6 @@
+@import '@/styles/main';
+
+.wrapper {
+  @include flexbox;
+  height: 100vh;
+}

--- a/src/app/oauth/signup/[provider]/page.tsx
+++ b/src/app/oauth/signup/[provider]/page.tsx
@@ -1,0 +1,18 @@
+import classNames from 'classnames/bind';
+import SignupToKakao from '@/components/OAuth/SignupToKakao';
+import { OauthProvider } from '@/types/types';
+import styles from './OAuthSignup.module.scss';
+
+const cx = classNames.bind(styles);
+
+interface Props {
+  params: { provider: OauthProvider };
+}
+
+export default function OAuthSignup({ params: { provider } }: Props) {
+  return (
+    <section className={cx('wrapper')}>
+      {provider === OauthProvider.kakao ? <SignupToKakao /> : null}
+    </section>
+  );
+}

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -10,6 +10,7 @@ import styles from './signin.module.scss';
 import Button from '@/components/Button';
 import { checkSignEmail, checkSignPassword } from '@/utils/userValidation';
 import { signInUser } from '@/apis/postUserInfo';
+import SigninToKakao from '@/utils/SigninToKakao';
 
 const cx = classNames.bind(styles);
 
@@ -89,7 +90,7 @@ export default function SignInPage() {
                 height={32}
               />
             </div>
-            <div className={cx('sns-circle')}>
+            <div className={cx('sns-circle')} onClick={SigninToKakao}>
               <Image
                 className={cx('sns-image')}
                 src='./images/kakao-icon.svg'

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -10,7 +10,7 @@ import styles from './signin.module.scss';
 import Button from '@/components/Button';
 import { checkSignEmail, checkSignPassword } from '@/utils/userValidation';
 import { signInUser } from '@/apis/postUserInfo';
-import SigninToKakao from '@/utils/SigninToKakao';
+import signinToKakao from '@/utils/SigninToKakao';
 
 const cx = classNames.bind(styles);
 
@@ -90,7 +90,10 @@ export default function SignInPage() {
                 height={32}
               />
             </div>
-            <div className={cx('sns-circle')} onClick={SigninToKakao}>
+            <div
+              className={cx('sns-circle')}
+              onClick={() => signinToKakao('signin')}
+            >
               <Image
                 className={cx('sns-image')}
                 src='./images/kakao-icon.svg'

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -10,7 +10,7 @@ import styles from './signin.module.scss';
 import Button from '@/components/Button';
 import { checkSignEmail, checkSignPassword } from '@/utils/userValidation';
 import { signInUser } from '@/apis/postUserInfo';
-import signinToKakao from '@/utils/SigninToKakao';
+import signinToKakao from '@/utils/signinToKakao';
 
 const cx = classNames.bind(styles);
 
@@ -90,10 +90,7 @@ export default function SignInPage() {
                 height={32}
               />
             </div>
-            <div
-              className={cx('sns-circle')}
-              onClick={() => signinToKakao('signin')}
-            >
+            <div className={cx('sns-circle')} onClick={signinToKakao}>
               <Image
                 className={cx('sns-image')}
                 src='./images/kakao-icon.svg'

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -10,7 +10,7 @@ import styles from './signin.module.scss';
 import Button from '@/components/Button';
 import { checkSignEmail, checkSignPassword } from '@/utils/userValidation';
 import { signInUser } from '@/apis/postUserInfo';
-import signinToKakao from '@/utils/signinToKakao';
+import signToKakao from '@/utils/SigninKakao';
 
 const cx = classNames.bind(styles);
 
@@ -90,7 +90,7 @@ export default function SignInPage() {
                 height={32}
               />
             </div>
-            <div className={cx('sns-circle')} onClick={signinToKakao}>
+            <div className={cx('sns-circle')} onClick={signToKakao}>
               <Image
                 className={cx('sns-image')}
                 src='./images/kakao-icon.svg'

--- a/src/app/signin/signin.module.scss
+++ b/src/app/signin/signin.module.scss
@@ -73,6 +73,7 @@
   border: 1px solid;
   border-radius: 999px;
   border-color: $tertiary;
+  cursor: pointer;
 }
 
 .sns-image {

--- a/src/components/Input/UserInfoInput/UserInfoInput.module.scss
+++ b/src/components/Input/UserInfoInput/UserInfoInput.module.scss
@@ -4,6 +4,7 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
+  width: 100%;
 }
 
 .input-label {

--- a/src/components/OAuth/SignupToKakao/SignupToKakao.module.scss
+++ b/src/components/OAuth/SignupToKakao/SignupToKakao.module.scss
@@ -1,0 +1,13 @@
+@import '@/styles/main';
+
+.wrapper {
+  @include column-flexbox;
+  width: 640px;
+  gap: 60px;
+  @include tablet {
+    width: 440px;
+  }
+  @include mobile {
+    width: 335px;
+  }
+}

--- a/src/components/OAuth/SignupToKakao/index.tsx
+++ b/src/components/OAuth/SignupToKakao/index.tsx
@@ -6,6 +6,7 @@ import UserInfoInput from '@/components/Input/UserInfoInput';
 import { checkNickname } from '@/utils/userValidation';
 import styles from './SignupToKakao.module.scss';
 import Button from '@/components/Button';
+import signupToKakao from '@/utils/signupToKakao';
 
 const cx = classNames.bind(styles);
 
@@ -19,12 +20,11 @@ export default function SignupToKakao() {
     const result = checkNickname(value);
     setError(result);
   };
-  const onClick = () => {
+  const onClick = async () => {
     if (error) {
       return;
     }
-    // OAuth 로그인 로직
-    console.log(nickname);
+    signupToKakao(nickname);
   };
   return (
     <div className={cx('wrapper')}>

--- a/src/components/OAuth/SignupToKakao/index.tsx
+++ b/src/components/OAuth/SignupToKakao/index.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { ChangeEvent, useState } from 'react';
+import classNames from 'classnames/bind';
+import UserInfoInput from '@/components/Input/UserInfoInput';
+import { checkNickname } from '@/utils/userValidation';
+import styles from './SignupToKakao.module.scss';
+import Button from '@/components/Button';
+
+const cx = classNames.bind(styles);
+
+export default function SignupToKakao() {
+  const [nickname, setNickname] = useState('');
+  const [error, setError] = useState('닉네임을 입력해주세요');
+  const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setNickname(event.target.value);
+  };
+  const onBlur = (value: string) => {
+    const result = checkNickname(value);
+    setError(result);
+  };
+  const onClick = () => {
+    if (error) {
+      return;
+    }
+    // OAuth 로그인 로직
+    console.log(nickname);
+  };
+  return (
+    <div className={cx('wrapper')}>
+      <UserInfoInput
+        labelName='닉네임'
+        value={nickname}
+        onChange={(event) => onChange(event)}
+        onBlur={() => onBlur(nickname)}
+        error={error}
+      />
+      <Button category='primary' onClick={onClick}>
+        가입하기
+      </Button>
+    </div>
+  );
+}

--- a/src/components/Production/index.tsx
+++ b/src/components/Production/index.tsx
@@ -13,6 +13,7 @@ import CreateReview from '@/components/Modal/CreateReview';
 import { useModalStore } from '../../../providers/ModalStoreProvider.tsx';
 import CreateProduct from '../Modal/CreateProduct/index.tsx';
 import getUserToken from '@/utils/getUserToken.ts';
+import handleShareKakao from '@/utils/shareKakao.ts';
 
 interface Props {
   productData: ProductDetailType;
@@ -124,7 +125,10 @@ export default function Production({ productData, me }: Readonly<Props>) {
               </button>
             </div>
             <div className={cx('name__action')}>
-              <button className={cx('btn')}>
+              <button
+                className={cx('btn')}
+                onClick={() => handleShareKakao(productData)}
+              >
                 <Image
                   src={'/images/kakao-icon.svg'}
                   alt={'카카오아이콘'}

--- a/src/pages/api/auth/kakao-signin.ts
+++ b/src/pages/api/auth/kakao-signin.ts
@@ -1,0 +1,44 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { SignInResponse, SignInWithOauthRequestBody } from '@/types/types';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  try {
+    const { code } = req.query;
+
+    if (!code) {
+      throw new Error('failed to login to Kakao');
+    }
+    const body: SignInWithOauthRequestBody = {
+      redirectUri: 'http://localhost:3000/api/auth/kakao-signin',
+      token: code,
+    };
+
+    const response = await fetch(
+      `https://mogazoa-api.vercel.app/3-1/auth/signIn/kakao`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      },
+    );
+
+    const result: SignInResponse = await response.json();
+
+    if (response.ok) {
+      res.setHeader(
+        'Set-Cookie',
+        `accessToken=${result.accessToken}; Path=/; HttpOnly; Secure`,
+      );
+      res.redirect('/');
+    } else if (response.status === 403) {
+      res.redirect('/oauth/signup/kakao');
+    }
+  } catch (error) {
+    res.status(500).json('failed to sign up');
+  }
+}

--- a/src/pages/api/auth/kakao.ts
+++ b/src/pages/api/auth/kakao.ts
@@ -1,0 +1,48 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { SignInResponse, SignInWithOauthRequestBody } from '@/types/types';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  try {
+    const { code } = req.query;
+    console.log('인가코드 : ', code);
+
+    if (!code) {
+      throw new Error('failed to login to Kakao');
+    }
+    const body: SignInWithOauthRequestBody = {
+      redirectUri: 'http://localhost:3000/api/auth/kakao',
+      token: code,
+    };
+    console.log('request body: ', body);
+
+    const response = await fetch(
+      `https://mogazoa-api.vercel.app/3-1/auth/signIn/kakao`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      },
+    );
+
+    const result: SignInResponse = await response.json();
+    console.log(result);
+
+    if (response.ok) {
+      res.setHeader(
+        'Set-Cookie',
+        `accessToken=${result.accessToken}; Path=/; HttpOnly; Secure`,
+      );
+      res.redirect('/');
+    } else if (response.status === 403) {
+      res.redirect('/oauth/signup/kakao');
+    }
+  } catch (error) {
+    console.error(error);
+    res.status(500).json('failed to sign up');
+  }
+}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -323,7 +323,7 @@ export interface SignInRequestBody {
  *
  * Kakao 의 경우에는 인가 코드 입니다.
  */
-export type OauthToken = string;
+export type OauthToken = string | string[];
 
 /**
  * example: http://localhost:3000/oauth/kakao

--- a/src/utils/SigninKakao.ts
+++ b/src/utils/SigninKakao.ts
@@ -1,8 +1,8 @@
-const signinToKakao = () => {
+const signToKakao = () => {
   const uri = `${process.env.NEXT_PUBLIC_SIGNIN_REDIRECT_URI}`;
   window.Kakao.Auth.authorize({
     redirectUri: uri,
   });
 };
 
-export default signinToKakao;
+export default signToKakao;

--- a/src/utils/SigninToKakao.ts
+++ b/src/utils/SigninToKakao.ts
@@ -1,0 +1,7 @@
+const SigninToKakao = () => {
+  window.Kakao.Auth.authorize({
+    redirectUri: `${process.env.NEXT_PUBLIC_REDIRECT_URI}`,
+  });
+};
+
+export default SigninToKakao;

--- a/src/utils/SigninToKakao.ts
+++ b/src/utils/SigninToKakao.ts
@@ -1,7 +1,8 @@
-const SigninToKakao = () => {
+const signinToKakao = () => {
+  const uri = `${process.env.NEXT_PUBLIC_SIGNIN_REDIRECT_URI}`;
   window.Kakao.Auth.authorize({
-    redirectUri: `${process.env.NEXT_PUBLIC_REDIRECT_URI}`,
+    redirectUri: uri,
   });
 };
 
-export default SigninToKakao;
+export default signinToKakao;

--- a/src/utils/setCookieOAuth.ts
+++ b/src/utils/setCookieOAuth.ts
@@ -1,0 +1,9 @@
+'use server';
+
+import { cookies } from 'next/headers';
+
+const setCookieOAuth = async (accessToken: string) => {
+  cookies().set('accessToken', accessToken);
+};
+
+export default setCookieOAuth;

--- a/src/utils/shareKakao.ts
+++ b/src/utils/shareKakao.ts
@@ -1,0 +1,32 @@
+import { ProductDetailType } from '@/types/types';
+
+const handleShareKakao = (productData: ProductDetailType) => {
+  const { Kakao, location } = window;
+  Kakao.Share.sendDefault({
+    objectType: 'feed',
+    content: {
+      title: productData.name,
+      description: productData.description,
+      imageUrl: productData.image,
+      link: {
+        mobileWebUrl: location.href,
+        webUrl: location.href,
+      },
+    },
+    social: {
+      likeCount: productData.favoriteCount,
+      commentCount: productData.reviewCount,
+    },
+    buttons: [
+      {
+        title: '확인하러 가기',
+        link: {
+          mobileWebUrl: location.href,
+          webUrl: location.href,
+        },
+      },
+    ],
+  });
+};
+
+export default handleShareKakao;

--- a/src/utils/signupToKakao.ts
+++ b/src/utils/signupToKakao.ts
@@ -1,0 +1,6 @@
+const signupToKakao = (nickname: string) => {
+  const uri = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY}&redirect_uri=${process.env.NEXT_PUBLIC_SIGNUP_REDIRECT_URI}&response_type=code&state=${encodeURIComponent(nickname)}`;
+  window.location.href = uri;
+};
+
+export default signupToKakao;


### PR DESCRIPTION
### PR Type

- [x] 기능개발(Feature)
- [ ] 버그수정(Bugfix)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
- 카카오톡 공유하기 기능 구현
- 카카오톡 간편로그인/회원가입 기능 구현
- 간편로그인(카카오톡) 회원가입을 위한 페이지 제작

### 상세 내용(Describe your changes)
- 구글 간편로그인 로직이 어떻게 되는지 몰라서 
  `{provider === OauthProvider.kakao ? <SignupToKakao /> : null}` 분리해서 렌더링하게 했습니다. 
- 구글 로그인 실패시 `/oauth/signup/google` 경로로 이동시키고, 컴포넌트 만들어서 넣으시면 될것 같습니다.
- 추가된 환경변수는 디스코드 채널에 올리도록 하겠습니다. 팀장님께서 vercel에 업데이트 해주세요!

### 이미지
<img width="315" alt="image" src="https://github.com/Codeit-FE3-Part4-team1-Final/Mogazoa/assets/85405709/9138b6bd-2b11-4ed2-8430-cfe3855a02b9">
